### PR TITLE
update usage, improve causal mask

### DIFF
--- a/modules/positional_embeddings/alibi/alibi_positional_embeddings.py
+++ b/modules/positional_embeddings/alibi/alibi_positional_embeddings.py
@@ -104,12 +104,14 @@ class AlibiPositionEmbeddings(nn.Module):
 
         # paper authors note that they only trained models that have 2^a heads for some a.
         # This has beneficial properties related to input being power of 2.
+
         # Closest power of 2 below is workaround for when num of heads is not power of 2
+        # Slopes are returned in ordered sequence to keep symmetry.
 
         closest_power_of_2 = 2 ** math.floor(math.log2(num_heads))
-        return (
-            get_slopes_power_of_2(closest_power_of_2)
-            + get_slopes_power_of_2(2 * closest_power_of_2)[0::2][
-                : num_heads - closest_power_of_2
-            ]
-        )
+
+        a = get_slopes_power_of_2(closest_power_of_2)
+        b = get_slopes_power_of_2(2 * closest_power_of_2)[0::2][
+            : num_heads - closest_power_of_2
+        ]
+        return [x for pair in zip(b, a) for x in pair] + a[len(b) :]

--- a/modules/positional_embeddings/alibi/test_alibi.py
+++ b/modules/positional_embeddings/alibi/test_alibi.py
@@ -47,7 +47,11 @@ class TestAlibiPositionEmbedding:
     def num_heads(self):
         return 8
 
-    def test_alibi_mask(
+    @pytest.fixture
+    def num_heads_non_power_2(self):
+        return 12
+
+    def test_alibi_mask_power_of_2(
         self,
         max_seq_len,
         num_heads,
@@ -97,6 +101,89 @@ class TestAlibiPositionEmbedding:
         assert_expected(
             base_mask[num_heads - 1][max_seq_len - 1],
             expected_last_head_row,
+            rtol=0,
+            atol=1e-4,
+        )
+
+    def test_alibi_mask_non_power_of_2(
+        self,
+        max_seq_len,
+        num_heads_non_power_2,
+    ):
+        alibi_class = AlibiPositionEmbeddings(
+            max_seq_len=max_seq_len, num_heads=num_heads_non_power_2
+        )
+        base_mask = alibi_class.get_attention_mask(max_seq_len)
+
+        # verify mask shape
+        expected_shape = torch.Size((num_heads_non_power_2, max_seq_len, max_seq_len))
+        assert_expected(base_mask.shape, expected_shape)
+
+        # verify alibi mask components
+        expected_second_head_last_row = torch.tensor(
+            [
+                -7.5000,
+                -7.0000,
+                -6.5000,
+                -6.0000,
+                -5.5000,
+                -5.0000,
+                -4.5000,
+                -4.0000,
+                -3.5000,
+                -3.0000,
+                -2.5000,
+                -2.0000,
+                -1.5000,
+                -1.0000,
+                -0.5000,
+                0.0000,
+            ]
+        )
+
+        expected_third_head_last_row = torch.tensor(
+            [
+                -5.3033,
+                -4.9497,
+                -4.5962,
+                -4.2426,
+                -3.8891,
+                -3.5355,
+                -3.1820,
+                -2.8284,
+                -2.4749,
+                -2.1213,
+                -1.7678,
+                -1.4142,
+                -1.0607,
+                -0.7071,
+                -0.3536,
+                0.0000,
+            ]
+        )
+
+        expected_first_head_first_row_first_entry = torch.tensor(
+            0.0000,
+        )
+
+        assert_expected(
+            base_mask[0][0][0],
+            expected_first_head_first_row_first_entry,
+            rtol=0,
+            atol=1e-4,
+        )
+
+        # verify 2nd and 3rd head to confirm non power 2 symmetry of slopes
+        assert_expected(
+            base_mask[1][max_seq_len - 1],
+            expected_second_head_last_row,
+            rtol=0,
+            atol=1e-4,
+        )
+
+        assert_expected(
+            base_mask[2][max_seq_len - 1],
+            expected_third_head_last_row,
             rtol=0,
             atol=1e-4,
         )


### PR DESCRIPTION
This PR updates three items:
a - the usage comments are updated to properly note alibi is applied after sqrt scaling of QKT.
b - the causal mask is now made so that 0 is used for valid instead of 1.  (very minor difference, but this now perfectly mirrors the paper).
c - static method for get_slopes

Test updates:
Tests have been updated to reflect the 0 instead of 1 causal mask. 