### PR TITLE
Expand unit tests

### DIFF
--- a/dev/sr/tests/core_unit_tests.py
+++ b/dev/sr/tests/core_unit_tests.py
@@ -71,10 +71,8 @@ class TestStochasticRounding(unittest.TestCase):
         tensor_size = 10000 # TODO - should be 10K
         x = torch.full((tensor_size,), value, device='cuda')
 
-
-
         # Debug prints
-        print(f"Input value: {value}")
+        print(f"\nInput value: {value}")
 
         # Single round test first
         single_result = stochastic_rounding_cuda.stochastic_round_bf16(x)
@@ -113,7 +111,7 @@ class TestStochasticRounding(unittest.TestCase):
         x = torch.full((tensor_size,), value, device='cuda')
 
         # Debug prints
-        print(f"Input value: {value}")
+        print(f"\nInput value: {value}")
 
         # Single round test first
         single_result = stochastic_rounding_cuda.stochastic_round_bf16(x)
@@ -139,8 +137,10 @@ class TestStochasticRounding(unittest.TestCase):
         self.assertTrue(abs(prob_up - expected_prob) < 0.03)
 
     def test_rounding_statistics_small(self):
-        """Test stochastic rounding for number < 1"""
+        """Test stochastic rounding for number between 0 and 1"""
         value = 0.7499847412109375  # Should round between 0.7480 and 0.7500
+
+        print(f"\nInput value: {value}")
         tensor_size = 10000
         x = torch.full((tensor_size,), value, device='cuda')
         torch.cuda.manual_seed(42)
@@ -163,8 +163,10 @@ class TestStochasticRounding(unittest.TestCase):
         self.assertTrue(abs(prob_up - expected_prob) < 0.03)
 
     def test_rounding_statistics_large(self):
-        """Test stochastic rounding for large number, ala > 100"""
+        """Test stochastic rounding for large number, over 100"""
         value = 128.99998474121094  # Should round between 128.875 and 129.000
+        # Debug prints
+        print(f"\nInput value: {value}")
         tensor_size = 10000
         x = torch.full((tensor_size,), value, device='cuda')
         torch.cuda.manual_seed(42)


### PR DESCRIPTION
Added more unit tests for statistical rounding (arguably the most important aspect for this kernel). 
Adds a test for < 1, > 100 and an additional mid-range test.

~~~
test_large_values (__main__.TestStochasticRounding.test_large_values)
Test handling of large values ... ok
test_rounding_statistics (__main__.TestStochasticRounding.test_rounding_statistics)
Test if rounding probabilities match expected distribution ... 
Input value: 2.1999969482421875
Possible rounded values: tensor([2.1875, 2.2031], device='cuda:0', dtype=torch.bfloat16)
Kernel's probability of rounding up: 0.7996
Expected probability: 0.8011
ok
test_rounding_statistics_2 (__main__.TestStochasticRounding.test_rounding_statistics_2)
Test stochastic rounding with different BF16 boundary values ... 
Input value: 1.7999992370605469
Possible rounded values: tensor([1.7969, 1.8047], device='cuda:0', dtype=torch.bfloat16)
Kernel's probability of rounding up: 0.4004
Expected probability: 0.3973
ok
test_rounding_statistics_large (__main__.TestStochasticRounding.test_rounding_statistics_large)
Test stochastic rounding for large number, over 100 ... 
Input value: 128.99998474121094
Kernel's probability of rounding up: 1.0000
Expected probability: 0.9999
ok
test_rounding_statistics_small (__main__.TestStochasticRounding.test_rounding_statistics_small)
Test stochastic rounding for number between 0 and 1 ... 
Input value: 0.7499847412109375
Kernel's probability of rounding up: 0.9960
Expected probability: 0.9924
ok
test_small_values (__main__.TestStochasticRounding.test_small_values)
Test handling of small values near zero ... ok
test_special_values (__main__.TestStochasticRounding.test_special_values)
Test handling of special values like inf, -inf, nan ... ok
test_vectorized_loading (__main__.TestStochasticRounding.test_vectorized_loading)
Test if vectorized loading works correctly for different tensor sizes ... ok

----------------------------------------------------------------------
Ran 8 tests in 1.246s

OK
~~~