### PR TITLE
redo Philox to OOP class for easy maintenance

### DIFF
--- a/dev/sr/src/stochastic_rounding.cu
+++ b/dev/sr/src/stochastic_rounding.cu
@@ -1,8 +1,10 @@
-#include "stochastic_rounding.hpp"
+
 #include <pybind11/pybind11.h>
+#include "stochastic_rounding.hpp"
+#include <random>
+
 namespace py = pybind11;
 
-// Implementation of getOptimalBlockSize
 __host__ int getOptimalBlockSize() {
     cudaDeviceProp prop;
     cudaGetDeviceProperties(&prop, 0);
@@ -14,53 +16,39 @@ torch::Tensor stochastic_round_bf16_cuda(torch::Tensor input, bool requires_grad
     TORCH_CHECK(input.is_contiguous(), "Input tensor must be contiguous");
     TORCH_CHECK(input.scalar_type() == torch::kFloat32, "Input tensor must be float32");
 
-    // Get device properties
-    cudaDeviceProp prop;
-    cudaGetDeviceProperties(&prop, 0);
-
-    const int threads_per_block = 256;  // Fixed size for better occupancy
+    const int threads_per_block = 256;
     const int num_elements = input.numel();
-    const int elements_per_thread = 4;  // Vector size
+    const int elements_per_thread = 4;
 
-    // Calculate minimum blocks needed
     const int min_blocks = (num_elements + elements_per_thread * threads_per_block - 1) /
                           (elements_per_thread * threads_per_block);
 
-    // Ensure at least 2 blocks per SM
+    cudaDeviceProp prop;
+    cudaGetDeviceProperties(&prop, 0);
     const int blocks_per_sm = 4;
     const int min_blocks_for_sms = prop.multiProcessorCount * blocks_per_sm;
+    const int num_blocks = std::max(min_blocks, min_blocks_for_sms);
 
-    // Use maximum of calculated blocks and minimum blocks per SM
-    const int blocks = std::max(min_blocks, min_blocks_for_sms);
-
-    // Create output tensor
     auto options = torch::TensorOptions()
                       .dtype(torch::kBFloat16)
                       .device(input.device())
                       .requires_grad(requires_grad);
     auto output = torch::empty_like(input, options);
 
-    // Generate random seed
     std::random_device rd;
     std::mt19937_64 gen(rd());
     std::uniform_int_distribution<unsigned long long> dis;
     const unsigned long long seed = dis(gen);
 
-    // Launch kernel
-    stochastic_round_bf16<<<blocks, threads_per_block>>>(
+    stochastic_round_bf16<<<num_blocks, threads_per_block>>>(
         input.data_ptr<float>(),
-        reinterpret_cast<__nv_bfloat16 *>(output.data_ptr()),
+        reinterpret_cast<__nv_bfloat16*>(output.data_ptr()),
         num_elements,
         seed);
 
-    // Check for errors
     cudaError_t err = cudaGetLastError();
     TORCH_CHECK(err == cudaSuccess,
                 "CUDA kernel execution failed: ", cudaGetErrorString(err));
-
-    err = cudaDeviceSynchronize();
-    TORCH_CHECK(err == cudaSuccess,
-                "CUDA synchronization failed: ", cudaGetErrorString(err));
 
     return output;
 }

--- a/dev/sr/src/stochastic_rounding.hpp
+++ b/dev/sr/src/stochastic_rounding.hpp
@@ -1,61 +1,39 @@
+
 #pragma once
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
-#include <vector_types.h>  // for uint2, uint4
-#include <random>
+#include <vector_types.h>
 #include <torch/extension.h>
 #include <pybind11/pybind11.h>
 
-// Philox RNG constants
-namespace philox_constants {
-    constexpr unsigned int PHILOX_W32_0   = 0x9E3779B9;
-    constexpr unsigned int PHILOX_W32_1   = 0xBB67AE85;
-    constexpr unsigned int PHILOX_M0      = 0xD2511F53;
-    constexpr unsigned int PHILOX_M1      = 0xCD9E8D57;
+namespace philox {
+    constexpr unsigned int W32_0   = 0x9E3779B9;
+    constexpr unsigned int W32_1   = 0xBB67AE85;
+    constexpr unsigned int M0      = 0xD2511F53;
+    constexpr unsigned int M1      = 0xCD9E8D57;
+    constexpr int ROUNDS          = 7;
 }
 
-// Vector types declarations
-struct alignas(16) float8 {
-    float x[8];
-};
-
-struct alignas(8) float2_aligned {
-    float x[2];
-};
-
-// Philox RNG class declaration
-class Philox {
+// Forward declarations
+class PhiloxGenerator {
 public:
-    __device__ __forceinline__ Philox();
+    __device__ __forceinline__ PhiloxGenerator();
     __device__ __forceinline__ void init(const unsigned long long seed, const unsigned int thread_id);
-    __device__ __forceinline__ uint4 operator()();
+    __device__ __forceinline__ uint4 next();
 private:
     uint2 key;
     uint4 counter;
-    static __device__ __forceinline__ uint2 mulhilo32(const unsigned int a, const unsigned int b);
-    static __device__ __forceinline__ uint4 single_round(const uint4 ctr, const uint2 key);
+    static __device__ __forceinline__ uint2 mulhilo(const unsigned int a, const unsigned int b);
+    static __device__ __forceinline__ uint4 round(uint4 ctr, uint2 key);
 };
 
-// BF16 conversion helper
-__device__ __forceinline__ __nv_bfloat16 float_to_bf16_stochastic(float value, uint32_t rand32);
-
-// Forward declaration of helper device function
-__device__ __forceinline__ void float4_to_bf16_stochastic(
-    const float4& values,
-    uint4& rand_vals,
-    __nv_bfloat16* output);
-
-// Forward declaration of CUDA kernel
+// CUDA kernel declaration
 __global__ void stochastic_round_bf16(
     float *__restrict__ input,
     __nv_bfloat16 *__restrict__ output,
     const int size,
     const unsigned long long seed);
 
-// Get optimal block size - declaration only
+// Host functions
 __host__ int getOptimalBlockSize();
-
-
-
-// C++ wrapper for the CUDA kernel - declaration only
 torch::Tensor stochastic_round_bf16_cuda(torch::Tensor input, bool requires_grad = false);


### PR DESCRIPTION
ThIs PR reworks the Philox into a PhiloxGenerator class to add init, round, and next for easy use and maintenance.